### PR TITLE
Docs: fix old action path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This GHA is used to generate the "Deployment Frequency" metric in our Engineerin
 
 ```yaml
 - name: Report Deployment
-  uses: digitalservicebund/github-actions/track-deployment@34a48d29a9c4cc2fd6710b8eb37e13618a08fa88
+  uses: digitalservicebund/track-deployment@LATEST_HASH
   with:
     project: PROJECT_NAME
     environment: ENVIRONMENT


### PR DESCRIPTION
This action repository has been moved from a mono-repository. Thereby the old action path that was still documented is obsolete.

PS:
I took the `LATEST_HASH` naming/annotation choice from the [create-sbom](https://github.com/digitalservicebund/create-sbom) action. 🤷🏾 